### PR TITLE
Use design time layout attributes to show placeholder text.

### DIFF
--- a/app/src/main/res/layout/dialog_place.xml
+++ b/app/src/main/res/layout/dialog_place.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
@@ -11,7 +12,8 @@
             android:id="@+id/address"
             android:layout_margin="5dp"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            tools:text="@string/place_item_address1"/>
 
         <ImageView
             android:id="@+id/dialog_maps_icon"
@@ -28,7 +30,8 @@
         android:id="@+id/address2"
         android:autoLink="all"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        tools:text="@string/place_item_address2"/>
 
 
     <View
@@ -41,7 +44,8 @@
         android:layout_margin="5dp"
         android:textStyle="italic"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        tools:text="@string/place_item_helpers"/>
 
     <ScrollView
         android:layout_width="fill_parent"
@@ -55,9 +59,9 @@
             android:id="@+id/items"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:layout_weight="1.0"/>
+            android:layout_weight="1.0"
+            tools:text="@string/place_item_items"/>
 
     </ScrollView>
-
 
 </LinearLayout>

--- a/app/src/main/res/layout/list_fragment.xml
+++ b/app/src/main/res/layout/list_fragment.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
         android:id="@+id/progress_container_id"
@@ -26,8 +27,7 @@
             android:text="@string/places_you_can_help"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:gravity="center_horizontal|center_vertical"
-            xmlns:android="http://schemas.android.com/apk/res/android"></TextView>
+            android:gravity="center_horizontal|center_vertical" />
 
         <TextView
             android:id="@+id/empty_id"
@@ -40,7 +40,8 @@
             android:id="@android:id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:drawSelectorOnTop="false" >
+            android:drawSelectorOnTop="false"
+            tools:listitem="@layout/row" >
         </ListView>
     </FrameLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/row.xml
+++ b/app/src/main/res/layout/row.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <LinearLayout
@@ -13,13 +15,15 @@
         <TextView
             android:id="@+id/distance"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:text="@string/place_item_distance" />
 
         <TextView
             android:id="@+id/name"
             android:textStyle="bold"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:text="@string/place_item_name" />
 
     </LinearLayout>
 
@@ -29,7 +33,8 @@
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:text="@string/place_item_address1" />
 
     <TextView
         android:id="@+id/list_address2"
@@ -38,7 +43,8 @@
         android:layout_marginRight="30dp"
         android:autoLink="all"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:text="@string/place_item_address2" />
 
     <TextView
         android:id="@+id/list_helpers"
@@ -46,7 +52,8 @@
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:text="@string/place_item_helpers" />
 
     <TextView
         android:id="@+id/list_items"
@@ -56,6 +63,7 @@
         android:layout_marginRight="20dp"
         android:layout_width="wrap_content"
         android:layout_marginBottom="20dp"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:text="@string/place_item_items" />
 
 </LinearLayout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Design time placeholders -->
+    <string name="place_item_name">
+        Pankow - Notunterkunft Storkower Str.
+    </string>
+    <string name="place_item_distance">
+        1548,5 km -
+    </string>
+    <string name="place_item_address1">
+        Storkower Str. 133a, 10147, Berlin
+    </string>
+    <string name="place_item_address2">
+        bis 18:30 Uhr
+    </string>
+    <string name="place_item_helpers">
+        @string/need_helpers
+    </string>
+    <string name="place_item_items">
+        Wasser, Duschgel, Kissen zum Schlafen, Einwegrasierer, Tampon,
+        Damenbinden verschiedene Größen, Zahnpasta, Zahnbürsten, Handtücher,
+        Deodorants!! Spray Deos, Decken, Bettzeug, Zucker und Salz
+    </string>
+
+</resources>


### PR DESCRIPTION
- I introduced design time layout attributes [1] in a few places
  to make it easier to understand and maintain the layouts.
- Move placeholders texts to dedicated file.

[1] http://tools.android.com/tips/layout-designtime-attributes
