### PR TITLE
Place dialog layout

### DIFF
--- a/app/src/main/java/com/helphelp2/android/PlaceDialogFragment.java
+++ b/app/src/main/java/com/helphelp2/android/PlaceDialogFragment.java
@@ -75,8 +75,11 @@ public class PlaceDialogFragment extends DialogFragment {
         View layout = inflater.inflate(R.layout.dialog_place, null);
         ButterKnife.bind(this, layout);
 
-        _addressTextView.setText(addr);
-        _itemsTextView.setText(items);
+        if (!TextUtils.isEmpty(addr)) {
+            _addressTextView.setText(addr);
+        } else {
+            _addressTextView.setVisibility(View.GONE);
+        }
 
         if (!TextUtils.isEmpty(addr2)) {
             _address2TextView.setText(Html.fromHtml(addr2));
@@ -88,6 +91,12 @@ public class PlaceDialogFragment extends DialogFragment {
             _helpersTextView.setText(R.string.need_helpers);
         } else {
             _helpersTextView.setVisibility(View.GONE);
+        }
+
+        if (!TextUtils.isEmpty(items)) {
+            _itemsTextView.setText(items);
+        } else {
+            _itemsTextView.setVisibility(View.GONE);
         }
 
         builder.setView(layout);

--- a/app/src/main/java/com/helphelp2/android/PlaceDialogFragment.java
+++ b/app/src/main/java/com/helphelp2/android/PlaceDialogFragment.java
@@ -96,7 +96,7 @@ public class PlaceDialogFragment extends DialogFragment {
         return builder.create();
     }
 
-    @OnClick(R.id.dialog_maps_icon)
+    @OnClick(R.id.address)
     public void onMapsIconClick() {
         if (TextUtils.isEmpty(addr)) {
             return;

--- a/app/src/main/res/layout/dialog_place.xml
+++ b/app/src/main/res/layout/dialog_place.xml
@@ -1,66 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
-        <TextView
-            android:id="@+id/address"
-            android:layout_margin="@dimen/place_dialog_margin"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="@string/place_item_address1"/>
-
-        <ImageView
-            android:id="@+id/dialog_maps_icon"
-            android:src="@drawable/maps_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
-
+    android:layout_height="wrap_content"
+    android:divider="?android:attr/listDivider"
+    android:orientation="vertical"
+    android:showDividers="middle"
+    tools:background="@android:color/holo_orange_light">
 
     <TextView
-        android:layout_marginLeft="@dimen/place_dialog_margin"
-        android:layout_marginRight="@dimen/place_dialog_margin"
-        android:layout_marginBottom="@dimen/place_dialog_margin"
+        android:id="@+id/address"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/place_dialog_margin"
+        android:drawableEnd="@drawable/maps_icon"
+        android:drawableRight="@drawable/maps_icon"
+        android:gravity="center_vertical"
+        tools:background="@android:color/holo_blue_light"
+        tools:text="@string/place_item_address1" />
+
+    <TextView
         android:id="@+id/address2"
-        android:autoLink="all"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        tools:text="@string/place_item_address2"/>
-
-
-    <View
-        android:layout_width="fill_parent"
-        android:layout_height="1dp"
-        android:background="@color/place_dialog_divider"/>
+        android:layout_marginBottom="@dimen/place_dialog_margin"
+        android:layout_marginLeft="@dimen/place_dialog_margin"
+        android:layout_marginRight="@dimen/place_dialog_margin"
+        android:layout_marginTop="@dimen/place_dialog_margin"
+        android:autoLink="all"
+        tools:background="@android:color/holo_blue_light"
+        tools:text="@string/place_item_address2" />
 
     <TextView
         android:id="@+id/helpers"
-        android:layout_margin="@dimen/place_dialog_margin"
-        android:textStyle="italic"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        tools:text="@string/place_item_helpers"/>
+        android:layout_margin="@dimen/place_dialog_margin"
+        android:textStyle="italic"
+        tools:background="@android:color/holo_blue_light"
+        tools:text="@string/place_item_helpers" />
 
     <ScrollView
-        android:layout_width="fill_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:scrollbars="vertical"
-        android:layout_weight="1"
         android:layout_margin="@dimen/place_dialog_margin"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:scrollbars="vertical">
 
         <TextView
             android:id="@+id/items"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_weight="1.0"
-            tools:text="@string/place_item_items"/>
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:background="@android:color/holo_blue_light"
+            tools:text="@string/place_item_items" />
 
     </ScrollView>
 

--- a/app/src/main/res/layout/dialog_place.xml
+++ b/app/src/main/res/layout/dialog_place.xml
@@ -10,47 +10,29 @@
 
     <TextView
         android:id="@+id/address"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/place_dialog_margin"
-        android:drawableEnd="@drawable/maps_icon"
-        android:drawableRight="@drawable/maps_icon"
-        android:gravity="center_vertical"
+        style="@style/PlaceView.Address"
         tools:background="@android:color/holo_blue_light"
         tools:text="@string/place_item_address1" />
 
     <TextView
         android:id="@+id/address2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/place_dialog_margin"
-        android:layout_marginLeft="@dimen/place_dialog_margin"
-        android:layout_marginRight="@dimen/place_dialog_margin"
-        android:layout_marginTop="@dimen/place_dialog_margin"
-        android:autoLink="all"
+        style="@style/PlaceView.Address2"
         tools:background="@android:color/holo_blue_light"
         tools:text="@string/place_item_address2" />
 
     <TextView
         android:id="@+id/helpers"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/place_dialog_margin"
-        android:textStyle="italic"
+        style="@style/PlaceView.Helpers"
         tools:background="@android:color/holo_blue_light"
         tools:text="@string/place_item_helpers" />
 
     <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/place_dialog_margin"
-        android:fillViewport="true"
-        android:scrollbars="vertical">
+        style="@style/PlaceView.ScrollView"
+        tools:background="@android:color/holo_red_dark">
 
         <TextView
             android:id="@+id/items"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            style="@style/PlaceView.Items"
             tools:background="@android:color/holo_blue_light"
             tools:text="@string/place_item_items" />
 

--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -5,9 +5,6 @@
     <color name="primary_dark">#731a63</color>
     <color name="accent">#0396A6</color>
 
-    <!-- Place dialog -->
-    <color name="place_dialog_divider">@android:color/darker_gray</color>
-
     <!-- Place row -->
     <color name="place_row_list_items_text">#888888</color>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -12,6 +12,6 @@
     <dimen name="place_row_secondary_margin_right">20dp</dimen>
 
     <!-- Place dialog -->
-    <dimen name="place_dialog_margin">5dp</dimen>
+    <dimen name="place_dialog_margin">8dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,4 +8,42 @@
         <item name="colorAccent">@color/accent</item>
     </style>
 
+    <!-- Abstract styles -->
+
+    <style name="PlaceView">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:padding">@dimen/place_dialog_margin</item>
+    </style>
+
+    <style name="PlaceView.Selectable" parent="PlaceView">
+        <item name="android:background">?attr/selectableItemBackground</item>
+    </style>
+
+    <!-- Place -->
+
+    <style name="PlaceView.Address" parent="PlaceView.Selectable">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:drawableRight">@drawable/maps_icon</item>
+        <item name="android:drawableEnd">@drawable/maps_icon</item>
+        <item name="android:gravity">center_vertical</item>
+    </style>
+
+    <style name="PlaceView.Address2" parent="PlaceView.Selectable">
+        <item name="android:autoLink">all</item>
+    </style>
+
+    <style name="PlaceView.Helpers" parent="PlaceView">
+        <item name="android:textStyle">italic</item>
+    </style>
+
+    <style name="PlaceView.ScrollView" parent="PlaceView">
+        <item name="android:padding">0dp</item>
+        <item name="android:fillViewport">true</item>
+        <item name="android:scrollbars">vertical</item>
+        <item name="android:scrollbarStyle">outsideOverlay</item>
+    </style>
+
+    <style name="PlaceView.Items" parent="PlaceView"/>
+
 </resources>


### PR DESCRIPTION
I refactored the place dialog to simplify the XML.
- I was able to **remove the custom divider views** by using `android:divider` set on the `LinearLayout`. 
- Then I **combined** the address and the maps icon into one view and put some effort in the positioning. 
- Also I added **visual touch feedback** to the address views.
- Last but not least, **empty views are hidden** at runtime.
